### PR TITLE
Use progressbar for getting Reddit userinfo and downloading

### DIFF
--- a/redditScraper.py
+++ b/redditScraper.py
@@ -6,6 +6,8 @@ import settings
 import submission
 from submission import Submission 
 
+from tqdm import tqdm
+
 #import pprint
 
 user_agent = 'Python Script: v2.0: Reddit Liked Saved Image Downloader (by /u/makuto9)'
@@ -22,10 +24,8 @@ def getSubmissionsFromRedditList(redditList, source,
     submissions = []
     comments = []
 
-    numTotalSubmissions = len(redditList)
-    for currentSubmissionIndex, singleSubmission in enumerate(redditList):
-        if currentSubmissionIndex and currentSubmissionIndex % 100 == 0:
-            logger.log('Got {} submissions...'.format(currentSubmissionIndex))
+    pbar = tqdm(redditList)
+    for singleSubmission in pbar:
 
         # If they don't want to save their own post, skip it
         submissionAuthor = singleSubmission.author.name if singleSubmission.author else u'no_author'
@@ -51,8 +51,6 @@ def getSubmissionsFromRedditList(redditList, source,
 
             submissions.append(newSubmission)
 
-            logger.log(percentageComplete(currentSubmissionIndex, numTotalSubmissions))
-
             if unlikeUnsave:
                 if source == 'liked':
                     singleSubmission.clear_vote()
@@ -65,6 +63,8 @@ def getSubmissionsFromRedditList(redditList, source,
             if (earlyOutPoint 
                 and earlyOutPoint[0] 
                 and newSubmission.postUrl == earlyOutPoint[0].postUrl):
+                pbar.set_description("<early out point>")
+                pbar.close()
                 logger.log('Found early out point after ' + str(len(submissions)) + ' new submissions.'
                       ' If you e.g. changed your total requests value and want to go deeper, set'
                       ' Reddit_Try_Request_Only_New to False in your settings.txt')


### PR DESCRIPTION
#65 

Use `tqdm` to provide a progress bar for the `for` loops in `imageSaver.saveAllImages` and `redditScraper.getSubmissionsFromRedditList`.

This can provide as a reference if the author doesn't want to merge it wholesale.

A couple notes:
- use `tqdm.tqdm.write` to write messages instead of print/logger.log - this will write a message then move the progressbar down using tqdm to avoid multiple bars being printed out.
- use `tqdm.tqdm.close` to close bars before `break`ing from loops

I think `videoDownloader.downloadVideo` could use a subprogress bar like this:
```python
def downloadVideo():
    # snip

    class Hook:
        def __init__(self):
            self.bar = tqdm(total=100)
            self.progress = 0.0

        def update(self, d):
            if d["status"] == "finished":
                self.bar.close()
            elif d["status"] == "downloading":
                p = d["_percent_str"]
                p = float(p.replace("%", ""))
                self.bar.update(p - self.progress)
                self.progress = p
            else: # error
                self.bar.set_description("error (stopping)")
                self.bar.close()

    hook = Hook()

    youtubeDL_options = {
        "outtmpl": "{}/{}".format(outputPath, youtubeDL_filenameFormat),
        # TODO: Support playlists?
        "noplaylist": True,
        "writethumbnail": True,
        "writeinfojson": True,
        "logger": youtubeDlLogger,
        "progress_hooks": [hook.update],
    }

    youtubeDownloader = youtube_dl.YoutubeDL(youtubeDL_options)

    try:
        youtubeDownloader.download([url])
        hook.bar.close()  # note the manual close here after successful download
    except youtube_dl.utils.DownloadError as downloadError:
        print(downloadError)
        return (False, downloadError.__str__())
    except ssl.CertificateError as certError:
        print(certError)
        return (False, certError.__str__() + ". This is likely the website maintainer's fault.")
```

but I haven't tested it. I'm pretty sure that if this is called inside a loop that's already using tqdm, it'll automagically create a nested progress bar.