### PR TITLE
Stop unwanted SSL upgrades.

### DIFF
--- a/webInterface/randomImageBrowser.js
+++ b/webInterface/randomImageBrowser.js
@@ -66,7 +66,7 @@ function directoryOrFileOnClick(path, serverPath, type) {
         }
 
         if (type == "video") {
-            window.open("https://" + window.location.host + "/" + serverPath);
+            window.open("/" + serverPath);
         }
 
         if (type == "image") {
@@ -74,7 +74,7 @@ function directoryOrFileOnClick(path, serverPath, type) {
         }
 
         if (type == "file") {
-            window.open("https://" + window.location.host + "/" + serverPath);
+            window.open("/" + serverPath);
         }
     }
 }
@@ -103,7 +103,7 @@ function handleSetImage(messageDict) {
 	if (infiniteScroll) {
 		var infiniteScrollContainer = document.getElementById("infiniteScrollContainer");
 		var imageElement = document.createElement("img");
-		imageElement.src = 'https://' + window.location.host + '/' + messageDict.serverImagePath;
+		imageElement.src = '/' + messageDict.serverImagePath;
 		imageElement.className = "infiniteScrollImage";
 		infiniteScrollContainer.appendChild(imageElement);
 		// var infiniteScrollContainer = document.getElementById("infiniteScrollContainer");
@@ -128,7 +128,7 @@ function handleSetVideo(messageDict) {
 	if (infiniteScroll) {
 		var infiniteScrollContainer = document.getElementById("infiniteScrollContainer");
 		var videoElement = document.createElement("a");
-		videoElement.href = 'https://' + window.location.host + '/' + messageDict.serverImagePath;
+		videoElement.href = '/' + messageDict.serverImagePath;
 		videoElement.className = "infiniteScrollVideoLink";
 		var linkText = document.createTextNode("View Video " + messageDict.serverImagePath);
 		videoElement.appendChild(linkText);
@@ -142,8 +142,7 @@ function handleSetVideo(messageDict) {
 		  + messageDict.serverImagePath
 		  + '" type="video/mp4">Your browser does not support the video tag</video>';*/
 		var videoContainer = document.getElementById("videoContainer");
-		videoContainer.innerHTML = '<a class="bigCenterLink" target="_blank" href="https://' +
-			window.location.host + '/' + messageDict.serverImagePath +
+		videoContainer.innerHTML = '<a class="bigCenterLink" target="_blank" href="/' + messageDict.serverImagePath +
 			'">View Video ' + messageDict.serverImagePath + '</a>';
 	}
 }


### PR DESCRIPTION
If server is running in unsecure mode, HTTPS requests will time out.

 Fix this by referencing local instead of absolute paths.